### PR TITLE
Update link to Chinese README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # SGL (Small Graphics Library)
-# [中文](https://github.com/LiShanwenGit/sgl/blob/main/README_CN.md)
+# [中文](README_CN.md)
 
 ![SGL_LOGO](SGL_logo.png)
 


### PR DESCRIPTION
This PR updates the Chinese README link in root README.md from an absolute path (https://github.com/LiShanwenGit/sgl/blob/main/README_CN.md) to a relative path (README_CN.md) to prevent link failure from repo changes。